### PR TITLE
Issue template change: add anti-piracy warning

### DIFF
--- a/.github/ISSUE_TEMPLATE/app_bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/app_bug_report.yaml
@@ -17,6 +17,8 @@ body:
         If you are unsure, start with [discord](https://discord.com/invite/TCz3t9k) or the [forums](https://forums.pcsx2.net/index.php).
 
         Please make an effort to make sure your issue isn't already reported.
+        
+        Do not include suggestions that you may have pirated any software in your issue, or your issue will be closed. E.g. do not include logs that list more than one BIOS file.
 
         ### Please Avoid Issues Pertaining to the Following:
         - We are **not** accepting bug reports for **PSX mode** at this time.

--- a/.github/ISSUE_TEMPLATE/emu_bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/emu_bug_report.yaml
@@ -17,6 +17,8 @@ body:
         If you are unsure, start with [discord](https://discord.com/invite/TCz3t9k) or the [forums](https://forums.pcsx2.net/index.php).
 
         Please make an effort to make sure your issue isn't already reported.
+        
+        Do not include suggestions that you may have pirated any software in your issue, or your issue will be closed. E.g. do not include logs that list more than one BIOS file.
 
         ### Please Avoid Issues Pertaining to the Following:
         - We are **not** accepting bug reports for **PSX mode** at this time.

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -6,6 +6,15 @@ labels: ["Enhancement / Feature Request"]
 # assignees:
 #   - octocat
 body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Important: Read First
+
+        Please make an effort to make sure your issue isn't already reported.
+
+        Do not include suggestions that you may have pirated any software in your issue, or your issue will be closed. E.g. do not include logs that list more than one BIOS file.
+        
   - type: textarea
     id: desc
     attributes:


### PR DESCRIPTION
### Description of Changes
Added an anti-piracy warning to issue templates.

### Rationale behind Changes
Prevent invalid issues.

### Suggested Testing Steps
Test the issue template functions correctly.
